### PR TITLE
fix: remove double space in wizard step label

### DIFF
--- a/projects/workshop/src/app/patterns/wizard/vertical/vertical.docs.ts
+++ b/projects/workshop/src/app/patterns/wizard/vertical/vertical.docs.ts
@@ -103,7 +103,7 @@ export class VerticalWizardComponent {
       showErrorMessage: false,
     },
     {
-      stepLabel: 'Step 2  label',
+      stepLabel: 'Step 2 label',
       id: 'vertical-1',
       invalid: false,
       complete: false,


### PR DESCRIPTION
## Summary
- Remove extra space in `'Step 2  label'` → `'Step 2 label'` in the vertical wizard pattern docs
- Steps 1, 3, 4, and 5 all use single space; Step 2 had a double space

## Test plan
- No functional changes — string literal fix only
- Consistent with the formatting of all sibling step labels in the same array